### PR TITLE
SEC-1461-Updating Terrascan version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM koalaman/shellcheck:v0.7.1 as shellcheck
 FROM wata727/tflint:0.25.0 as tflint
 FROM alpine/terragrunt:0.14.5 as terragrunt
 FROM mvdan/shfmt:v3.2.4 as shfmt
-FROM accurics/terrascan:2d1374b as terrascan
+FROM accurics/terrascan:1.5.1 as terrascan
 FROM hadolint/hadolint:latest-alpine as dockerfile-lint
 FROM ghcr.io/assignuser/lintr-lib:0.2.0 as lintr-lib
 FROM ghcr.io/assignuser/chktex-alpine:0.1.1 as chktex


### PR DESCRIPTION
Currently  the version of terrascan in superlinter in pinned to 2d1374b and we need to upgrade it to 1.5.1


