### PR TITLE
SEC-1471 Use dedicated temp files for linter stdout output.

### DIFF
--- a/lib/functions/lintly.sh
+++ b/lib/functions/lintly.sh
@@ -35,44 +35,42 @@ function AddLinterOptsForLintly() {
   [[ ! "${LINTER_OPTS[DOCKERFILE_HADOLINT]}" =~ "json" ]] && LINTER_OPTS[DOCKERFILE_HADOLINT]+=" --format json"
   [[ ! "${LINTER_OPTS[TERRAFORM_TERRASCAN]}" =~ "json" ]] && LINTER_OPTS[TERRAFORM_TERRASCAN]+=" -o json"
   [[ ! "${LINTER_OPTS[CLOUDFORMATION_CFN_NAG]}" =~ "json" ]] && LINTER_OPTS[CLOUDFORMATION_CFN_NAG]+=" --output-format=json"
-  # gitleaks with either --verbose or --quiet will write extra logs to stdout and mess up our report; remove these
-  LINTER_OPTS[GITLEAKS]=${LINTER_OPTS[GITLEAKS]// --quiet/} && \
-      LINTER_OPTS[GITLEAKS]=${LINTER_OPTS[GITLEAKS]// -q/} && \
-      LINTER_OPTS[GITLEAKS]=${LINTER_OPTS[GITLEAKS]// --verbose/} && \
-      LINTER_OPTS[GITLEAKS]=${LINTER_OPTS[GITLEAKS]// -v/}
 }
 ################################################################################
 #### Function InvokeLintly #####################################################
 function InvokeLintly() {
   # Call comes through as:
-  # InvokeLintly "${LINTLY_FORMAT}" "${LINTER_COMMAND_OUTPUT}"
+  # InvokeLintly "${FILE_TYPE}" ${FILE} "${LINTER_COMMAND_OUTPUT_FILE}"
 
   ####################
   # Pull in the vars #
   ####################
-  LINTLY_FORMAT="${1}"
-  LINTLY_FILE_OVERRIDE="${2}"
-  LINTER_COMMAND_OUTPUT="${3}"
+  FILE_TYPE="${1}"
+  FILE="${2}"
+  LINTER_COMMAND_OUTPUT_FILE="${3}"
+  LINTLY_FORMAT="${LINTLY_SUPPORT_ARRAY[${FILE_TYPE}]}"
 
   debug "----<<<<INVOKING Invokelintly>>>>----"
   debug "FORMAT: ${LINTLY_FORMAT}"
-  debug "OUTPUT: ${LINTER_COMMAND_OUTPUT}"
+  debug "OUTPUT: $(<${LINTER_COMMAND_OUTPUT_FILE})"
   debug ""
   debug "DONE DISPLAYING ARGUMENTS"
 
   LINTLY_LOG=""
-  if [[ ${ACTIONS_RUNNER_DEBUG} == true ]]; then LINTLY_LOG="--log"; fi
+  if [[ ${ACTIONS_RUNNER_DEBUG} ]]; then LINTLY_LOG="--log"; fi
 
+  # Some linter tools may not provide a full path and filename. Use env var to "hint" to Lintly
+  # what the repo-relative path should be.
+  export LINTLY_FILE_OVERRIDE="${FILE}"
   # Lintly will comment on the PR
-  export LINTLY_FILE_OVERRIDE="${LINTLY_FILE_OVERRIDE}"
-  echo "$LINTER_COMMAND_OUTPUT" | lintly "${LINTLY_LOG}" --format="${LINTLY_FORMAT}"
+  lintly "${LINTLY_LOG}" --format="${LINTLY_FORMAT}" < "${LINTER_COMMAND_OUTPUT_FILE}"
 
   debug "$?"
   debug "^^ exit code ^^"
 }
 ################################################################################
-#### Function IsLintly #########################################################
-function IsLintly() {
+#### Function OutputToLintly ###################################################
+function OutputToLintly() {
   [[ "${OUTPUT_MODE}" == lintly ]]
 }
 ################################################################################

--- a/lib/functions/lintly.sh
+++ b/lib/functions/lintly.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 ################################################################################
 ################################################################################
 ########### Super-Linter lintly Function(s) @scriptsrc #########################
@@ -23,7 +22,7 @@ LINTLY_SUPPORT_ARRAY['DOCKERFILE_HADOLINT']="hadolint"
 LINTLY_SUPPORT_ARRAY['CLOUDFORMATION']="cfn-lint"
 LINTLY_SUPPORT_ARRAY['CLOUDFORMATION_CFN_NAG']="cfn-nag"
 LINTLY_SUPPORT_ARRAY['GITLEAKS']="gitleaks"
-export LINTLY_SUPPORT_ARRAY                      # Workaround SC2034
+export LINTLY_SUPPORT_ARRAY # Workaround SC2034
 
 ########################## FUNCTION CALLS BELOW ################################
 ################################################################################
@@ -52,7 +51,7 @@ function InvokeLintly() {
 
   debug "----<<<<INVOKING Invokelintly>>>>----"
   debug "FORMAT: ${LINTLY_FORMAT}"
-  debug "OUTPUT: $(<${LINTER_COMMAND_OUTPUT_FILE})"
+  debug "OUTPUT: $(<"${LINTER_COMMAND_OUTPUT_FILE}")"
   debug ""
   debug "DONE DISPLAYING ARGUMENTS"
 
@@ -63,7 +62,7 @@ function InvokeLintly() {
   # what the repo-relative path should be.
   export LINTLY_FILE_OVERRIDE="${FILE}"
   # Lintly will comment on the PR
-  lintly "${LINTLY_LOG}" --format="${LINTLY_FORMAT}" < "${LINTER_COMMAND_OUTPUT_FILE}"
+  lintly "${LINTLY_LOG}" --format="${LINTLY_FORMAT}" <"${LINTER_COMMAND_OUTPUT_FILE}"
 
   debug "$?"
   debug "^^ exit code ^^"

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -104,7 +104,7 @@ EDITORCONFIG_FILE_NAME="${EDITORCONFIG_FILE_NAME:-.ecrc}"
 # shellcheck disable=SC2034  # Variable is referenced indirectly
 GHERKIN_FILE_NAME=".gherkin-lintrc"
 # shellcheck disable=SC2034  # Variable is referenced indirectly
-[[ ! -z ${GITLEAKS_CONFIG_FILE} ]] && GITLEAKS_FILE_NAME=${GITLEAKS_CONFIG_FILE}    # Use built-in default rules if none were provided
+[[ -n ${GITLEAKS_CONFIG_FILE} ]] && GITLEAKS_FILE_NAME=${GITLEAKS_CONFIG_FILE} # Use built-in default rules if none were provided
 # shellcheck disable=SC2034  # Variable is referenced indirectly
 GO_FILE_NAME=".golangci.yml"
 # shellcheck disable=SC2034  # Variable is referenced indirectly
@@ -324,11 +324,6 @@ RAW_FILE_ARRAY=()                   # Array of all files that were changed
 export RAW_FILE_ARRAY               # Workaround SC2034
 TEST_CASE_FOLDER='.automation/test' # Folder for test cases we should always ignore
 export TEST_CASE_FOLDER             # Workaround SC2034
-
-##############
-# Output     #
-##############
-OUTPUT_MODE="${OUTPUT_MODE}"
 
 ##########################
 # Array of changed files #

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -767,7 +767,7 @@ GetStandardRules "typescript"
 #################################
 # Define extra opts for linters #
 #################################
-if IsLintly; then
+if OutputToLintly; then
   AddLinterOptsForLintly
 fi
 for K in "${!LINTER_OPTS[@]}"; do
@@ -797,7 +797,7 @@ LINTER_COMMANDS_ARRAY['EDITORCONFIG']="editorconfig-checker -config ${EDITORCONF
 LINTER_COMMANDS_ARRAY['ENV']="dotenv-linter"
 LINTER_COMMANDS_ARRAY['GHERKIN']="gherkin-lint -c ${GHERKIN_LINTER_RULES}"
 # Need --no-git to scan an individual file rather than scanning commit histories.
-LINTER_COMMANDS_ARRAY['GITLEAKS']="gitleaks --config-path=${GITLEAKS_LINTER_RULES} --redact --no-git ${LINTER_OPTS[GITLEAKS]}"
+LINTER_COMMANDS_ARRAY['GITLEAKS']="gitleaks --config-path=${GITLEAKS_LINTER_RULES} --verbose --redact --no-git ${LINTER_OPTS[GITLEAKS]}"
 LINTER_COMMANDS_ARRAY['GO']="golangci-lint run -c ${GO_LINTER_RULES}"
 LINTER_COMMANDS_ARRAY['GROOVY']="npm-groovy-lint -c ${GROOVY_LINTER_RULES} --failon warning"
 LINTER_COMMANDS_ARRAY['HTML']="htmlhint --config ${HTML_LINTER_RULES}"


### PR DESCRIPTION
super-linter mixes stderr with stdout, which can confuse Lintly (e.g., [SEC-1471](https://23andme.atlassian.net/browse/SEC-1471)). This PR keeps the existing functionality of logging stderr to stdout, while keeping stdout separate in a temp file that we feed to Lintly.

(Also some Lintly-related cleanup while we're here.)