### PR TITLE
SEC-1481 Fixed cfn-lint informational bit mask.

### DIFF
--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -251,7 +251,7 @@ function LintCodebase() {
           cd "${WORKSPACE_PATH}" || exit
           ${LINTER_COMMAND} "${FILE}" 2>&1 > >(tee "${LINT_OUTPUT_ONLY_FILE}")
           # Clear the 'informational' bit in cfn-lint's exit status.
-          exit $(($? & ~0x100))
+          exit $(($? & ~0x8))
         )
       ###########################################################
       # Corner case for CFN_NAG as path is passed inside a flag #


### PR DESCRIPTION
`0x100` is hex representation (`0b0001 0000 0000`in binary), duh.