### PR TITLE
SEC-1498 Switched to using slim Docker image.

### DIFF
--- a/.github/workflows/deploy-ttam.yml
+++ b/.github/workflows/deploy-ttam.yml
@@ -55,12 +55,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      ###################################################################
+      # Checkout the code base (required for docker path context below) #
+      ###################################################################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
       ###########################################
       # Build and Push containers to registries #
       ###########################################
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          context: .
+          file: ./Dockerfile-slim
           build-args: |
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ github.sha }}

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -27,6 +27,7 @@ FROM hadolint/hadolint:latest-alpine as dockerfile-lint
 FROM assignuser/chktex-alpine:v0.1.1 as chktex
 FROM garethr/kubeval:0.15.0 as kubeval
 FROM ghcr.io/assignuser/lintr-lib:0.3.0 as lintr-lib
+FROM zricethezav/gitleaks:v7.4.0 as gitleaks
 
 ##################
 # Get base image #
@@ -184,6 +185,11 @@ COPY --from=shfmt /bin/shfmt /usr/bin/
 #################
 COPY --from=lintr-lib /usr/lib/R/library/ /home/r-library
 RUN R -e "install.packages(list.dirs('/home/r-library',recursive = FALSE), repos = NULL, type = 'source')"
+
+####################
+# Install gitleaks #
+####################
+COPY --from=gitleaks /usr/bin/gitleaks /usr/bin/
 
 ##################
 # Install ktlint #


### PR DESCRIPTION
Branch that set things up to test these changes: https://github.com/23andMe/super-linter/tree/SEC-1498-slim-docker-test
Example PR that ran on slim docker container: https://github.com/23andme-private/sarahc/pull/37/files
GH Actions run of the above: https://github.com/23andme-private/sarahc/actions/runs/1157499669

Not all that much smaller, oh well. But hopefully it means shorter build times and slightly less of a headache wrt dependency management?
```
REPOSITORY                                   TAG           IMAGE ID       CREATED          SIZE
ghcr.io/23andme/super-linter                 latest-slim   f79a7454f0ac   19 minutes ago   3.58GB
ghcr.io/23andme/super-linter                 latest        87e498bb861e   4 days ago       5.08GB
```