### PR TITLE
SEC-1692 adding global ignore rule for gitleaks nosec

### DIFF
--- a/TEMPLATES/.gitleaks.toml
+++ b/TEMPLATES/.gitleaks.toml
@@ -173,3 +173,7 @@ title = "gitleaks config"
     files = ['''^\.?gitleaks.toml$''',
     '''(.*?)(png|jpg|gif|doc|docx|pdf|bin|xls|pyc|zip)$''',
     '''(go.mod|go.sum)$''']
+    
+[allowlist]
+    description = "ignore #nosec lines"
+    regexes = ['''#nosec''']


### PR DESCRIPTION
adding global ignore rule for gitleaks nosec, so that any false positive secrets that have nosec on the same line will be ignored.