### PR TITLE
SEC-1585 Fixed super-linter so that builds only fail if there are new issues on changed lines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,6 @@ But if you wish to select or exclude specific linters, we give you full control 
 | **LINTER_RULES_PATH**              | `.github/linters`               | Directory for all linter configuration rules.                                                                                                                                                                        |
 | **LOG_FILE**                       | `super-linter.log`              | The filename for outputting logs. All output is sent to the log file regardless of `LOG_LEVEL`.                                                                                                                     |
 | **LOG_LEVEL**                      | `VERBOSE`                       | How much output the script will generate to the console. One of `ERROR`, `WARN`, `NOTICE`, `VERBOSE`, `DEBUG` or `TRACE`.                                                                                            |
-| **MULTI_STATUS**                   | `true`                          | A status API is made for each language that is linted to make visual parsing easier.                                                                                                                                 |
 | **MARKDOWN_CONFIG_FILE**           | `.markdown-lint.yml`            | Filename for [Markdownlint configuration](https://github.com/DavidAnson/markdownlint#optionsconfig) (ex: `.markdown-lint.yml`, `.markdownlint.json`, `.markdownlint.yaml`)                                           |
 | **MARKDOWN_CUSTOM_RULE_GLOBS**     | `.markdown-lint/rules,rules/**` | Comma-separated list of [file globs](https://github.com/igorshubovych/markdownlint-cli#globbing) matching [custom Markdownlint rule files](https://github.com/DavidAnson/markdownlint/blob/main/doc/CustomRules.md). |
 | **PHP_CONFIG_FILE**                | `php.ini`                       | Filename for [PHP Configuration](https://www.php.net/manual/en/configuration.file.php) (ex: `php.ini`)                                                                                                               |
@@ -428,6 +427,12 @@ As a result, the `VALIDATE_[LANGUAGE]` variables behave differently from those i
 | **COMPLIANT_FILTER**                   | `none`            | URLs to approved dependencies repository sources.                                                                         |
 | **VALIDATE_PYTHON_BANDIT**             | `true`            | Flag to enable or disable the linting process of the Python with bandit.                                                  |
 | **VALIDATE_SEMGREP**                   | `true`            | Flag to enable or disable the using semgrep to check potentially all files of all languages.                              |
+
+The following environment variables were **removed** in 23andMe's super-linter.
+
+| **ENV VAR**                            | **Default Value** | **Notes**                                                                                                                                                        |
+| -------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MULTI_STATUS**                       | `true`            | A status API is made for each language that is linted to make visual parsing easier. Removed in 23andMe's fork as Lintly will being setting individual statuses. |
 
 The following is a list of supported language packs.
 

--- a/lib/functions/lintly.sh
+++ b/lib/functions/lintly.sh
@@ -67,8 +67,10 @@ function InvokeLintly() {
   # Lintly will comment on the PR
   lintly "${LINTLY_LOG}" --format="${LINTLY_FORMAT}" <"${LINTER_COMMAND_OUTPUT_FILE}"
 
-  debug "$?"
-  debug "^^ exit code ^^"
+  LINTLY_ERROR_CODE=$?
+  debug "${LINTLY_ERROR_CODE}"
+  debug "^^ Lintly exit code ^^"
+  return ${LINTLY_ERROR_CODE}
 }
 ################################################################################
 #### Function OutputToLintly ###################################################

--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -329,6 +329,16 @@ function LintCodebase() {
       # Check for if it was supposed to pass #
       ########################################
       if [[ ${FILE_STATUS} == "good" ]]; then
+
+        #############################################################################################
+        # If Lintly was called, let Lintly set the error code instead.                              #
+        # With LINTLY_FAIL_ON=new, Lintly fails builds only if issues are found on changed *lines*. #
+        #############################################################################################
+        if OutputToLintly && SupportsLintly "${FILE_TYPE}"; then
+          InvokeLintly "${FILE_TYPE}" "${FILE}" "${LINT_OUTPUT_ONLY_FILE}"
+          ERROR_CODE=$?
+        fi
+
         ##############################
         # Check the shell for errors #
         ##############################
@@ -340,22 +350,12 @@ function LintCodebase() {
             ########
             warn "Warnings found in [${LINTER_NAME}] linter!"
             warn "${LINT_CMD}"
-
-            if OutputToLintly && SupportsLintly "${FILE_TYPE}"; then
-              InvokeLintly "${FILE_TYPE}" "${FILE}" "${LINT_OUTPUT_ONLY_FILE}"
-            fi
-
           else
             #########
             # Error #
             #########
             error "Found errors in [${LINTER_NAME}] linter!"
             error "Error code: ${ERROR_CODE}. Command output:${NC}\n------\n${LINT_CMD}\n------"
-
-            if OutputToLintly && SupportsLintly "${FILE_TYPE}"; then
-              InvokeLintly "${FILE_TYPE}" "${FILE}" "${LINT_OUTPUT_ONLY_FILE}"
-            fi
-
             # Increment the error count
             (("ERRORS_FOUND_${FILE_TYPE}++"))
           fi

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -346,7 +346,6 @@ export LANGUAGE_PACKS
 # GitHub ENV Vars #
 ###################
 # ANSIBLE_DIRECTORY="${ANSIBLE_DIRECTORY}"         # Ansible Directory
-MULTI_STATUS="${MULTI_STATUS:-true}"       # Multiple status are created for each check ran
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-master}" # Default Git Branch to use (master by default)
 # DISABLE_ERRORS="${DISABLE_ERRORS}"               # Boolean to enable warning-only output without throwing errors
 # FILTER_REGEX_INCLUDE="${FILTER_REGEX_INCLUDE}"   # RegExp defining which files will be processed by linters (all by default)
@@ -566,122 +565,6 @@ GetGitHubVars() {
       info "Successfully found:${F[W]}[GITHUB_REPO]${F[B]}, value:${F[W]}[${GITHUB_REPO}]"
     fi
   fi
-
-  ############################
-  # Validate we have a value #
-  ############################
-  if [ -z "${GITHUB_TOKEN}" ] && [[ ${RUN_LOCAL} == "false" ]]; then
-    error "Failed to get [GITHUB_TOKEN]!"
-    error "[${GITHUB_TOKEN}]"
-    error "Please set a [GITHUB_TOKEN] from the main workflow environment to take advantage of multiple status reports!"
-
-    ################################################################################
-    # Need to set MULTI_STATUS to false as we cant hit API endpoints without token #
-    ################################################################################
-    MULTI_STATUS='false'
-  else
-    info "Successfully found:${F[W]}[GITHUB_TOKEN]"
-  fi
-
-  ###############################
-  # Convert string to lowercase #
-  ###############################
-  MULTI_STATUS="${MULTI_STATUS,,}"
-
-  #######################################################################
-  # Check to see if the multi status is set, and we have a token to use #
-  #######################################################################
-  if [ "${MULTI_STATUS}" == "true" ] && [ -n "${GITHUB_TOKEN}" ]; then
-    ############################
-    # Validate we have a value #
-    ############################
-    if [ -z "${GITHUB_REPOSITORY}" ]; then
-      error "Failed to get [GITHUB_REPOSITORY]!"
-      fatal "[${GITHUB_REPOSITORY}]"
-    else
-      info "Successfully found:${F[W]}[GITHUB_REPOSITORY]${F[B]}, value:${F[W]}[${GITHUB_REPOSITORY}]"
-    fi
-
-    ############################
-    # Validate we have a value #
-    ############################
-    if [ -z "${GITHUB_RUN_ID}" ]; then
-      error "Failed to get [GITHUB_RUN_ID]!"
-      fatal "[${GITHUB_RUN_ID}]"
-    else
-      info "Successfully found:${F[W]}[GITHUB_RUN_ID]${F[B]}, value:${F[W]}[${GITHUB_RUN_ID}]"
-    fi
-  fi
-}
-################################################################################
-#### Function CallStatusAPI ####################################################
-CallStatusAPI() {
-  ####################
-  # Pull in the vars #
-  ####################
-  LANGUAGE="${1}" # langauge that was validated
-  STATUS="${2}"   # success | error
-  SUCCESS_MSG='No errors were found in the linting process'
-  FAIL_MSG='Errors were detected, please view logs'
-  MESSAGE='' # Message to send to status API
-
-  debug "Calling Multi-Status API for $LANGUAGE with status $STATUS"
-
-  ######################################
-  # Check the status to create message #
-  ######################################
-  if [ "${STATUS}" == "success" ]; then
-    # Success
-    MESSAGE="${SUCCESS_MSG}"
-  else
-    # Failure
-    MESSAGE="${FAIL_MSG}"
-  fi
-
-  ##########################################################
-  # Check to see if were enabled for multi Status mesaages #
-  ##########################################################
-  if [ "${MULTI_STATUS}" == "true" ] && [ -n "${GITHUB_TOKEN}" ] && [ -n "${GITHUB_REPOSITORY}" ]; then
-
-    # make sure we honor DISABLE_ERRORS
-    if [ "${DISABLE_ERRORS}" == "true" ]; then
-      STATUS="success"
-    fi
-
-    debug "URL: ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}"
-
-    ##############################################
-    # Call the status API to create status check #
-    ##############################################
-    SEND_STATUS_CMD=$(
-      curl -f -s -X POST \
-        --url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
-        -H 'accept: application/vnd.github.v3+json' \
-        -H "authorization: Bearer ${GITHUB_TOKEN}" \
-        -H 'content-type: application/json' \
-        -d "{ \"state\": \"${STATUS}\",
-        \"target_url\": \"https://${GITHUB_DOMAIN:-github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\",
-        \"description\": \"${MESSAGE}\", \"context\": \"--> Linted: ${LANGUAGE}\"
-      }" 2>&1
-    )
-
-    #######################
-    # Load the error code #
-    #######################
-    ERROR_CODE=$?
-
-    debug "Send status comd output: [$SEND_STATUS_CMD]"
-
-    ##############################
-    # Check the shell for errors #
-    ##############################
-    if [ "${ERROR_CODE}" -ne 0 ]; then
-      # ERROR
-      info "ERROR! Failed to call GitHub Status API!"
-      info "ERROR:[${SEND_STATUS_CMD}]"
-      # Not going to fail the script on this yet...
-    fi
-  fi
 }
 ################################################################################
 #### Function Footer ###########################################################
@@ -697,40 +580,6 @@ Footer() {
   ####################################################
   mapfile -t UNIQUE_LINTED_ARRAY < <(for LANG in "${LINTED_LANGUAGES_ARRAY[@]}"; do echo "${LANG}"; done | sort -u)
   export UNIQUE_LINTED_ARRAY # Workaround SC2034
-
-  ##############################
-  # Prints for errors if found #
-  ##############################
-  for LANGUAGE in "${LANGUAGE_ARRAY[@]}"; do
-    ###########################
-    # Build the error counter #
-    ###########################
-    ERROR_COUNTER="ERRORS_FOUND_${LANGUAGE}"
-
-    ##################
-    # Print if not 0 #
-    ##################
-    if [[ ${!ERROR_COUNTER} -ne 0 ]]; then
-      # We found errors in the language
-      ###################
-      # Print the goods #
-      ###################
-      error "ERRORS FOUND${NC} in ${LANGUAGE}:[${!ERROR_COUNTER}]"
-
-      #########################################
-      # Create status API for Failed language #
-      #########################################
-      CallStatusAPI "${LANGUAGE}" "error"
-      ######################################
-      # Check if we validated the langauge #
-      ######################################
-    elif [[ ${!ERROR_COUNTER} -eq 0 ]]; then
-      if CheckInArray "${LANGUAGE}"; then
-        # No errors found when linting the language
-        CallStatusAPI "${LANGUAGE}" "success"
-      fi
-    fi
-  done
 
   ##################################
   # Exit with 0 if errors disabled #


### PR DESCRIPTION
1. Remove all calls in super-linter to GitHub's status endpoints. Lintly is aware of and can already filter findings based on changed lines. We will delegate setting build status to Lintly instead.
2. Since super-linter no longer sets any statuses, we will now need Lintly to set `success` statuses too. Previously, super-linter calls Lintly only if a particular linter found issues. Now we should always call Lintly (as long as Lintly supports that linter).
3. super-linter should cue its exit code off of Lintly's exit code now (rather than off of each individual linter's exit code, which can contain issues in an unchanged part of a file).
4. We need to update each individual workflow file to set `LINTLY_FAIL_ON_ANY` to `new`, unfortunately (sorry).