### PR TITLE
SEC-2408: Removed old claimable S3 URL from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ The design of the **Super-Linter** is currently to allow linting to occur in **G
 
 ### Repository Visualization
 
-![Visualization of the codebase](https://super-linter.s3.us-west-2.amazonaws.com/diagram.svg)
-
 ## Supported Linters
 
 Developers on **GitHub** can call the **GitHub Action** to lint their codebase with the following list of linters:


### PR DESCRIPTION
## Remove Claimable S3 Bucket Reference
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Anyone can claim this S3 bucket reference and display their own content on our public github page.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Delete the line referencing the S3 bucket.
## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
